### PR TITLE
UseDeferredEnumeration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,6 @@ Your ⭐ on [this repository][Repository] also helps! Thanks! 🖖🙂
 ## Installation
 QueryableValues is distributed as a [NuGet Package]. The major version number of this library is aligned with the version of [Entity Framework Core] by which it's supported (e.g. If you are using EF Core 5, then you must use version 5 of QueryableValues).
 
-Please choose the appropriate command below to install it using the NuGet Package Manager Console window in Visual Studio:
-
-EF Core | Command
-:---: | ---
-3.x | `Install-Package BlazarTech.QueryableValues.SqlServer -Version 3.5.0`
-5.x | `Install-Package BlazarTech.QueryableValues.SqlServer -Version 5.5.0`
-6.x | `Install-Package BlazarTech.QueryableValues.SqlServer -Version 6.5.0`
-7.x | `Install-Package BlazarTech.QueryableValues.SqlServer -Version 7.0.0`
-
 ## Configuration
 Look for the place in your code where you are setting up your [DbContext] and calling the [UseSqlServer] extension method, then use a lambda expression to access the `SqlServerDbContextOptionsBuilder` provided by it. It is on this builder that you must call the `UseQueryableValues` extension method as shown in the following simplified examples:
 

--- a/Version.xml
+++ b/Version.xml
@@ -1,8 +1,8 @@
 ﻿<Project>
 	<PropertyGroup>
-		<VersionEFCore3>3.5.0</VersionEFCore3>
-		<VersionEFCore5>5.5.0</VersionEFCore5>
-		<VersionEFCore6>6.5.0</VersionEFCore6>
-		<VersionEFCore7>7.0.0</VersionEFCore7>
+		<VersionEFCore3>3.6.0</VersionEFCore3>
+		<VersionEFCore5>5.6.0</VersionEFCore5>
+		<VersionEFCore6>6.6.0</VersionEFCore6>
+		<VersionEFCore7>7.1.0</VersionEFCore7>
 	</PropertyGroup>
 </Project>

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,15 +34,6 @@ Your ⭐ on [this repository][Repository] also helps! Thanks! 🖖🙂
 ## Installation
 QueryableValues is distributed as a [NuGet Package]. The major version number of this library is aligned with the version of [Entity Framework Core] by which it's supported (e.g. If you are using EF Core 5, then you must use version 5 of QueryableValues).
 
-Please choose the appropriate command below to install it using the NuGet Package Manager Console window in Visual Studio:
-
-EF Core | Command
-:---: | ---
-3.x | `Install-Package BlazarTech.QueryableValues.SqlServer -Version 3.5.0`
-5.x | `Install-Package BlazarTech.QueryableValues.SqlServer -Version 5.5.0`
-6.x | `Install-Package BlazarTech.QueryableValues.SqlServer -Version 6.5.0`
-7.x | `Install-Package BlazarTech.QueryableValues.SqlServer -Version 7.0.0`
-
 ## Configuration
 Look for the place in your code where you are setting up your [DbContext] and calling the [UseSqlServer] extension method, then use a lambda expression to access the `SqlServerDbContextOptionsBuilder` provided by it. It is on this builder that you must call the `UseQueryableValues` extension method as shown in the following simplified examples:
 

--- a/src/QueryableValues.SqlServer/QueryableValuesSqlServerOptions.cs
+++ b/src/QueryableValues.SqlServer/QueryableValuesSqlServerOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace BlazarTech.QueryableValues
+﻿using System;
+using System.Collections.Generic;
+
+namespace BlazarTech.QueryableValues
 {
     /// <summary>
     /// QueryableValues options for SQL Server.
@@ -6,6 +9,7 @@
     public sealed class QueryableValuesSqlServerOptions
     {
         internal bool WithUseSelectTopOptimization { get; private set; } = true;
+        internal bool WithUseDeferredEnumeration { get; private set; } = true;
 
         /// <summary>
         /// When possible, uses a <c>TOP(n)</c> clause in the underlying <c>SELECT</c> statement to assist SQL Server memory grant estimation. The default is <see langword="true"/>.
@@ -21,5 +25,29 @@
             WithUseSelectTopOptimization = useSelectTopOptimization;
             return this;
         }
+
+#if !EFCORE3
+        /// <summary>
+        /// If <see langword="true"/>, the <see cref="IEnumerable{T}"/> provided to any of the <c>AsQueryableValues</c> methods will be enumerated when the query is materialized; otherwise, it will be immediately enumerated once. The default is <see langword="true"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Leaving this feature enabled has the following advantages:<br/>
+        /// - If your sequence of values is behind an <see cref="IEnumerable{T}"/>, it will be enumerated only when needed.<br/>
+        /// - The sequence is enumerated every time the query is materialized, allowing the query to be aware of any changes done to the underlying sequence.
+        /// </para>
+        /// <para>
+        /// You may want to disable this feature if you rely on the <see cref="Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToQueryString(System.Linq.IQueryable)"/> method across your application.
+        /// As of EF 7.0, the implementation of that API is making incompatible assumptions about the underlying ADO.NET query parameters, resulting in an <see cref="InvalidCastException"/> when this option is enabled.
+        /// </para>
+        /// </remarks>
+        /// <param name="useDeferredEnumeration"></param>
+        /// <returns>The same <see cref="QueryableValuesSqlServerOptions"/> instance so subsequent configurations can be chained.</returns>
+        public QueryableValuesSqlServerOptions UseDeferredEnumeration(bool useDeferredEnumeration = true)
+        {
+            WithUseDeferredEnumeration = useDeferredEnumeration;
+            return this;
+        }
+#endif
     }
 }

--- a/src/QueryableValues.SqlServer/SqlServer/XmlQueryableFactory.cs
+++ b/src/QueryableValues.SqlServer/SqlServer/XmlQueryableFactory.cs
@@ -82,8 +82,7 @@ namespace BlazarTech.QueryableValues.SqlServer
             var xmlParameter = new SqlParameter(null, SqlDbType.Xml)
             {
                 // DeferredValues allows us to defer the enumeration of values until the query is materialized.
-                // Uses deferredValues.ToString() at evaluation time.
-                Value = deferredValues
+                Value = _options.WithUseDeferredEnumeration ? deferredValues : deferredValues.ToString(null)
             };
 
             if (UseSelectTopOptimization(deferredValues))
@@ -91,8 +90,7 @@ namespace BlazarTech.QueryableValues.SqlServer
                 // bigint to avoid implicit casting by the TOP operation (observed in the execution plan).
                 var countParameter = new SqlParameter(null, SqlDbType.BigInt)
                 {
-                    // Uses deferredValues.ToInt64() at evaluation time.
-                    Value = deferredValues
+                    Value = _options.WithUseDeferredEnumeration ? deferredValues : deferredValues.ToInt64(null)
                 };
 
                 sqlParameters = new[] { xmlParameter, countParameter };

--- a/tests/QueryableValues.SqlServer.Tests.EFCore3/QueryableValues.SqlServer.Tests.EFCore3.csproj
+++ b/tests/QueryableValues.SqlServer.Tests.EFCore3/QueryableValues.SqlServer.Tests.EFCore3.csproj
@@ -2,7 +2,7 @@
 	<Import Project="../SharedTestProjectProperties.xml" />
 	
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
 		<AssemblyName>BlazarTech.QueryableValues.SqlServer.Tests.EFCore3</AssemblyName>
 		<DefineConstants>$(DefineConstants);TESTS;EFCORE3</DefineConstants>
 	</PropertyGroup>

--- a/tests/QueryableValues.SqlServer.Tests.EFCore5/QueryableValues.SqlServer.Tests.EFCore5.csproj
+++ b/tests/QueryableValues.SqlServer.Tests.EFCore5/QueryableValues.SqlServer.Tests.EFCore5.csproj
@@ -2,7 +2,7 @@
 	<Import Project="../SharedTestProjectProperties.xml" />
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
 		<AssemblyName>BlazarTech.QueryableValues.SqlServer.Tests.EFCore5</AssemblyName>
 		<DefineConstants>$(DefineConstants);TESTS;EFCORE5</DefineConstants>
 	</PropertyGroup>


### PR DESCRIPTION
- Added a new option that allows you to disable **deferred enumeration**. By disabling this feature you will be able to use the [`ToQueryString`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.entityframeworkqueryableextensions.toquerystring) method provided by EF 5 onwards. If possible, I recommend leaving this feature enabled (default). For details please refer to the `UseDeferredEnumeration` method documentation.

Configuration example:
```c#
builder.UseQueryableValues(options =>
{
    options.UseDeferredEnumeration(false);
})
```

Provides a workaround for #25 .